### PR TITLE
URL Cleanup

### DIFF
--- a/gateway/src/main/resources/templates/index.html
+++ b/gateway/src/main/resources/templates/index.html
@@ -18,7 +18,7 @@
   ~
   -->
 
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org">
 <head>
 	<title>Spring Security - OAuth 2.0 Login</title>
 	<meta charset="utf-8" />


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.thymeleaf.org with 1 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 1 occurrences
* http://localhost:8080/login/oauth2/code/login-client with 1 occurrences
* http://localhost:8090/uaa with 1 occurrences
* http://localhost:8090/uaa/oauth/authorize with 1 occurrences
* http://localhost:8090/uaa/oauth/token with 1 occurrences
* http://localhost:8090/uaa/token_keys with 2 occurrences
* http://localhost:8090/uaa/userinfo with 1 occurrences
* http://localhost:9000 with 1 occurrences
* http://www.w3.org/1999/xhtml with 1 occurrences