### PR TITLE
Update Tomcat to latest 8.5.41 patch version.

### DIFF
--- a/uaa-server/build.gradle
+++ b/uaa-server/build.gradle
@@ -50,7 +50,7 @@ cargo {
     local {
         outputFile = file("$buildDir/uaa-server.log")
         installer {
-            installUrl = 'https://www-us.apache.org/dist/tomcat/tomcat-8/v8.5.35/bin/apache-tomcat-8.5.35.zip'
+            installUrl = 'https://www-us.apache.org/dist/tomcat/tomcat-8/v8.5.41/bin/apache-tomcat-8.5.41.zip'
 
             downloadDir = file("$buildDir/download")
             extractDir = file("$buildDir/extract")


### PR DESCRIPTION
Tomcat v8.5.35 is not available for download at the specified URL any more. This pull request updates the version of Tomcat to the latest 8.5 version (v8.5.41).