### PR TITLE
Update build.gradle to use latest URL for Tomcat backing the UAA

### DIFF
--- a/uaa-server/build.gradle
+++ b/uaa-server/build.gradle
@@ -13,7 +13,7 @@ repositories {
     mavenCentral()
 }
 
-ext.uaaVersion = '4.24.0'
+ext.uaaVersion = '4.30.0'
 
 configurations {
     uaa
@@ -50,7 +50,7 @@ cargo {
     local {
         outputFile = file("$buildDir/uaa-server.log")
         installer {
-            installUrl = 'https://www-us.apache.org/dist/tomcat/tomcat-8/v8.5.35/bin/apache-tomcat-8.5.35.zip'
+            installUrl = 'https://www-us.apache.org/dist/tomcat/tomcat-8/v8.5.43/bin/apache-tomcat-8.5.43.zip'
 
             downloadDir = file("$buildDir/download")
             extractDir = file("$buildDir/extract")


### PR DESCRIPTION
Update to the URL for the Tomcat download backing the UAA server. Update to the UAA version.